### PR TITLE
Update org references from haasonsaas to evalops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Harness - Unified OpenAI & Anthropic SDK Interface
 
-[![CI](https://github.com/haasonsaas/agent-harness/workflows/CI/badge.svg)](https://github.com/haasonsaas/agent-harness/actions)
+[![CI](https://github.com/evalops/agent-harness/workflows/CI/badge.svg)](https://github.com/evalops/agent-harness/actions)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/haasonsaas/agent-harness"
-Repository = "https://github.com/haasonsaas/agent-harness"
-Issues = "https://github.com/haasonsaas/agent-harness/issues"
+Homepage = "https://github.com/evalops/agent-harness"
+Repository = "https://github.com/evalops/agent-harness"
+Issues = "https://github.com/evalops/agent-harness/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Repo transferred from `haasonsaas` to `evalops` org
- Updated all GitHub URLs, package references, and documentation links from `haasonsaas` → `evalops`

🤖 Generated with [Claude Code](https://claude.com/claude-code)