### PR TITLE
Migrate CI workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]


### PR DESCRIPTION
## Summary
- Switch `test` job from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404`
- Matches evalops/llm-gateway#94

## Test plan
- [ ] CI passes on Blacksmith runners
- [ ] Python test matrix runs correctly