### PR TITLE
[agent-harness] Swap pip → uv in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e ".[dev]"
+        uv pip install --system -e ".[dev]"
     
     - name: Lint with ruff
       run: |


### PR DESCRIPTION
## Summary
- Replace `python -m pip install --upgrade pip` + `pip install -e ".[dev]"` with `astral-sh/setup-uv@v8.1.0` (pinned by full SHA) followed by `uv pip install --system -e ".[dev]"`.
- No version pin changes, no `--user`, no `pip install -U pip`.

## Why
Hardens CI against the PyPI partial-read timeouts that took down post-merge evals on `main` in `evalops/maestro-internal#1492`. `uv` resumes partial downloads and retries on connection drops by default, removing a class of transient failures that `pip` cannot recover from. This workflow has no CLI tool installs, so no `uv tool install` retry wrapper is needed — that pattern lands when CLI tools show up.

## Files changed
- `.github/workflows/ci.yml`

## Test plan
- [ ] Confirm all three matrix shards (`3.10`, `3.11`, `3.12`) pass `Install dependencies`.
- [ ] Confirm `ruff`, `black`, `mypy`, and `pytest` steps still resolve binaries from the system env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)